### PR TITLE
Issues/allow grid overrides to 0 (zero)

### DIFF
--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -397,7 +397,7 @@ OffsetSizeField = partial(
     null=True,
     blank=True,
     default=None,
-    min_value=1,
+    min_value=0,
     max_value=constants.GRID_SIZE
 )
 
@@ -406,7 +406,7 @@ PushSizeField = partial(
     null=True,
     blank=True,
     default=None,
-    min_value=1,
+    min_value=0,
     max_value=constants.GRID_SIZE
 )
 
@@ -415,7 +415,7 @@ PullSizeField = partial(
     null=True,
     blank=True,
     default=None,
-    min_value=1,
+    min_value=0,
     max_value=constants.GRID_SIZE
 )
 

--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -457,8 +457,8 @@ class Bootstrap3ColumnPlugin(CMSPlugin):
         return txt
 
     def get_class(self, device, element):
-        size = getattr(self, '{}_{}'.format(device, element))
-        if size:
+        size = getattr(self, '{}_{}'.format(device, element), None)
+        if size is not None:
             if element == 'col':
                 return 'col-{}-{}'.format(device, size)
             else:


### PR DESCRIPTION
It is incorrect to disallow 0 (zero) for offset, push and pull grid classes for the column plugin, because they are sometimes required to "reset" and offset, pull or push from a narrower screen size.

Example: `col-xs-10 col-xs-offset-2 col-sm-12 col-sm-offset-0`

The trailing `col-sm-offset-0` is required to reset the offset from the extra-small width. Without it, Bootstrap will attempt to make a full-width column, that is offset 2 columns.