### PR TITLE
fix admin modal rendering

### DIFF
--- a/aldryn_bootstrap3/__init__.py
+++ b/aldryn_bootstrap3/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/button/change_form.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/button/change_form.html
@@ -26,7 +26,6 @@
 
         .well-wrapper {
             display: block;
-            position: relative;
             width: 100%;
         }
 

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/button/change_form.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/button/change_form.html
@@ -2,7 +2,7 @@
 
 {% block field_sets %}
     <div class="well-wrapper">
-        <div class="well btn-preview js-btn-preview text-center clearfix">
+        <div class="well btn-preview js-btn-preview text-center">
             <p class="text-center text-muted"><span class="fa fa-fw fa-eye"></span> Preview</p>
             <a>Example Button</a>
         </div>
@@ -16,20 +16,17 @@
         }
 
         .well {
-            position: fixed;
             text-align: center;
-            z-index: 1000;
             width: inherit;
-            border-radius: 0;
-            top: 0;
-            left: 0;
+            height: 120px;
+            overflow: hidden;
+            border-radius: 3px 3px 0 0;
+            margin: 0;
         }
 
         .well-wrapper {
-            height: 90px;
-            float: left;
+            display: block;
             position: relative;
-            margin: 0%;
             width: 100%;
         }
 

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/image/change_form.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/image/change_form.html
@@ -4,10 +4,10 @@
 
 {% block field_sets %}
     <div class="well-wrapper">
-        <div class="well img-preview js-img-preview text-center clearfix">
+        <div class="well img-preview js-img-preview text-center">
             <p class="text-center text-muted"><span class="fa fa-fw fa-eye"></span> Preview</p>
 
-            <div class="img-wrapper js-img-wrapper" style="background-image: url('{% static 'aldryn_bootstrap3/img/img-placeholder.png' %}');"></div>
+            <div class="img-wrapper js-img-wrapper" style="background-image: url('{% static "aldryn_bootstrap3/img/img-placeholder.png" %}');"></div>
         </div>
     </div>
 
@@ -23,22 +23,18 @@
         }
 
         .well {
-            position: fixed;
             text-align: center;
-            z-index: 1000;
-            height: 240px;
             width: inherit;
-            border-radius: 0;
-            top: 0;
-            left: 0;
+            height: 240px;
+            border-radius: 3px 3px 0 0;
         }
 
         .well-wrapper {
-            height: 140px;
-            float: left;
+            display: block;
             position: relative;
-            margin: 0%;
             width: 100%;
+            height: 240px;
+            margin-top: -135px;
         }
 
         .img-preview img {
@@ -128,15 +124,13 @@
             width: 77px !important;
             margin-top: 0 !important;
         }
-
-
     </style>
 
     {{ block.super }}
 
     {# Javascript for preview (must be after the rest of the fields, because we rely on global variables set there. #}
     <script>
-        if (!$) {
+        if (!window.$) {
             $ = django.jQuery;
         }
         $(document).ready(function () {
@@ -220,6 +214,5 @@
 
         });
     </script>
-
 
 {% endblock %}

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/image/change_form.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/image/change_form.html
@@ -32,7 +32,6 @@
 
         .well-wrapper {
             display: block;
-            position: relative;
             width: 100%;
         }
 

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/image/change_form.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/image/change_form.html
@@ -27,14 +27,13 @@
             width: inherit;
             height: 240px;
             border-radius: 3px 3px 0 0;
+            margin: -80px 0 0 0;
         }
 
         .well-wrapper {
             display: block;
             position: relative;
             width: 100%;
-            height: 240px;
-            margin-top: -135px;
         }
 
         .img-preview img {

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/label/change_form.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/plugins/label/change_form.html
@@ -4,7 +4,7 @@
 
 {% block field_sets %}
     <div class="well-wrapper">
-        <div class="well label-preview js-label-preview text-center clearfix">
+        <div class="well label-preview js-label-preview text-center">
             <p class="text-center text-muted"><i class="fa fa-fw fa-eye"></i> Preview</p>
 
             <p><span class="label">Example Label</span></p>
@@ -25,21 +25,16 @@
         }
 
         .well {
-            height: 140px;
-            position: fixed;
             text-align: center;
-            z-index: 1000;
             width: inherit;
-            border-radius: 0;
-            top: 0;
-            left: 0;
+            height: 120px;
+            overflow: hidden;
+            border-radius: 3px 3px 0 0;
+            margin: 0;
         }
 
         .well-wrapper {
-            height: 120px;
-            float: left;
-            position: relative;
-            margin: 0%;
+            display: block;
             width: 100%;
         }
 


### PR DESCRIPTION
Related issue for cleanup: https://github.com/aldryn/aldryn-bootstrap3/issues/28

- modal fixes for image
- modal fixes for button
- modal fixes for label

should be like:
![image](https://cloud.githubusercontent.com/assets/270307/8253163/4bee3f06-168d-11e5-89ab-65c1a8004eea.png)

instead is:
![image](https://cloud.githubusercontent.com/assets/270307/8253167/566efc68-168d-11e5-86cf-6a16e590cab3.png)
