### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Fixed an issue with links not rendering target
 * Fixed an issue with links rendering empty class attribute
+* Enhance display of image name in structure board
 
 1.0.1 (2015-11-12)
 ------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.0.2 (UNRELEASED)
+------------------
+
+* Fixed an issue with links not rendering target
+* Fixed an issue with links rendering empty class attribute
+
 1.0.1 (2015-11-12)
 ------------------
 

--- a/aldryn_bootstrap3/__init__.py
+++ b/aldryn_bootstrap3/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -293,8 +293,6 @@ class Boostrap3ImagePlugin(CMSPlugin):
             txt = self.alt
         elif self.file.label:
             txt = self.file.label
-        if self.file:
-            txt += ' ({})'.format(self.file.url)
         return txt
 
     def srcset(self):

--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -286,14 +286,7 @@ class Boostrap3ImagePlugin(CMSPlugin):
     )
 
     def __str__(self):
-        txt = 'Image'
-        if self.file.name:
-            txt = self.file.name
-        elif self.alt:
-            txt = self.alt
-        elif self.file.label:
-            txt = self.file.label
-        return txt
+        return self.file.label
 
     def srcset(self):
         if not self.file:

--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -287,10 +287,12 @@ class Boostrap3ImagePlugin(CMSPlugin):
 
     def __str__(self):
         txt = 'Image'
-        if self.title:
-            txt = self.title
+        if self.file.name:
+            txt = self.file.name
         elif self.alt:
             txt = self.alt
+        elif self.file.label:
+            txt = self.file.label
         if self.file:
             txt += ' ({})'.format(self.file.url)
         return txt

--- a/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/button.html
+++ b/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/button.html
@@ -1,6 +1,7 @@
 {% load cms_tags %}
 
 <a href="{{ instance.get_link_url }}"
+   {% if instance.type == 'btn' or instance.txt_context or instance.classes %}
    class="
         {% if instance.type == 'btn' %}
             btn{% if instance.btn_context %} btn-{{ instance.btn_context }}{% endif %}
@@ -9,10 +10,16 @@
         {% else %}
             {% if instance.txt_context %}txt-{{ instance.txt_context }}{% endif %}
         {% endif %}
-        {% if instance.classes %} {{ instance.classes }}{% endif %}"
+        {% if instance.classes %} {{ instance.classes }}{% endif %}
+    "
+    {% endif %}
     {% if instance.type == 'btn' %}
         role="button"
-    {% endif %}>{% spaceless %}
+    {% endif %}
+    {% if instance.link_target %}
+        target="{{ instance.link_target }}"
+    {% endif %}
+    >{% spaceless %}
     {% if instance.icon_left %}{% with icon_class=instance.icon_left %}{% include 'aldryn_bootstrap3/plugins/includes/icon.html' %}{% endwith %}{% endif %}
 
     {{ instance.label }}


### PR DESCRIPTION
* Fixed an issue with links not rendering target
* Fixed an issue with links rendering empty class attribute
* Enhance display of image name in structure board

Example rendering:
![image](https://cloud.githubusercontent.com/assets/270307/11268904/d68cf30c-8eb3-11e5-9f8f-22be093d887e.png)
