### PR TITLE
allow children in link plugin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+
+* Allow children in link plugin
+
 1.0.4 (2015-11-24)
 ------------------
 

--- a/aldryn_bootstrap3/cms_plugins.py
+++ b/aldryn_bootstrap3/cms_plugins.py
@@ -174,6 +174,7 @@ class Bootstrap3ButtonCMSPlugin(CMSPluginBase):
     change_form_template = 'admin/aldryn_bootstrap3/plugins/button/change_form.html'
     render_template = 'aldryn_bootstrap3/plugins/button.html'
     text_enabled = True
+    allow_children = True
 
     fieldsets = (
         (None, {


### PR DESCRIPTION
it is a valid use case to nest things into a link plugin, in fact prior to CMS 3.2 it was allowed (since the allowed children setting was ignored by the structureboard, so you could nest by dragging in)