### PR TITLE
Fixes for content mode dnd upload

### DIFF
--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/css/base.css
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/css/base.css
@@ -179,7 +179,7 @@
 }
 .filer-dropzone.dz-drag-hover {
     background: #E5F8FF;
-    box-shadow: 0 0 0 1px #00BAFF;
+    box-shadow: 0 0 0 2px #00BAFF;
 }
 .popup .filer-dropzone.dz-drag-hover {
     box-shadow: none;

--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/css/base.css
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/css/base.css
@@ -177,14 +177,21 @@
 .filer-dropzone {
     position: relative;
 }
+.filer-dropzone.dz-drag-hover {
+    background: #E5F8FF;
+    box-shadow: 0 0 0 1px #00BAFF;
+}
+.popup .filer-dropzone.dz-drag-hover {
+    box-shadow: none;
+}
 .filer-dropzone.dz-drag-hover img {
-    opacity: 0.5;
+    opacity: 0.3;
 }
 .filer-dropzone-info-message,
 .filer-dropzone-error-message {
-    position: absolute;
-    top: 50%;
+    position: fixed;
     left: 50%;
+    bottom: 0;
     overflow: hidden;
     z-index: 2;
     color: #000;
@@ -192,11 +199,11 @@
     line-height: 20px;
     text-align: center;
     width: 270px;
-    margin: -50px 0 0 -150px;
+    margin: 0 0 50px -150px;
     padding: 15px;
     border-radius: 3px;
     background: #fff;
-    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.7);
 }
 .filer-dropzone-info-message .icon {
     font-size: 30px;

--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/js/dropzone.init.js
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/js/dropzone.init.js
@@ -83,7 +83,7 @@
                         dropzone.find(uploadSuccess).removeClass(hiddenClass);
                         if (file && file.status === 'success' && response) {
                             if (response.original_image) {
-                                dropzone.find(originalImage).find('>img').attr('src', response.original_image)
+                                dropzone.find(originalImage).attr('src', response.original_image)
                             }
                         }
                     },

--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/js/dropzone.init.js
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/js/dropzone.init.js
@@ -84,6 +84,13 @@
                         if (file && file.status === 'success' && response) {
                             if (response.original_image) {
                                 dropzone.find(originalImage).attr('src', response.original_image)
+                                // TODO this should be CMS.API call
+                                // FIXME only works on 3.2
+                                $('.cms-btn-publish').addClass('cms-btn-publish-active')
+                                    .removeClass('cms-btn-disabled')
+                                    .parent().show();
+                                $('.cms-toolbar-revert').removeClass('cms-toolbar-item-navigation-disabled');
+                                $(window).trigger('resize');
                             }
                         }
                     },

--- a/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/image.html
+++ b/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/image.html
@@ -10,63 +10,70 @@ TODO: currently we're always upscaling the image physically.
       does not seem to do that yet.
 {% endcomment %}
 
-{% addtoblock "css" %}<link rel="stylesheet" href="{% static 'aldryn_bootstrap3/css/base.css' %}">{% endaddtoblock %}
-{% addtoblock "js" %}<script src="{% static 'aldryn_bootstrap3/js/dropzone.min.js' %}"></script>{% endaddtoblock %}
-{% addtoblock "js" %}<script src="{% static 'aldryn_bootstrap3/js/dropzone.init.js' %}"></script>{% endaddtoblock %}
-
-{% if has_dnd_support %}
-    <div class="js-filer-dropzone filer-dropzone" data-filer-url="{% url 'admin:bootstrap3_image_ajax_upload' pk=instance.pk %}">
+{# only load js and css required for dnd upload if toolbar is available #}
+{% if request.toolbar and request.toolbar.show_toolbar and request.toolbar.edit_mode %}
+    {% addtoblock "css" %}<link rel="stylesheet" href="{% static 'aldryn_bootstrap3/css/base.css' %}">{% endaddtoblock %}
+    {% addtoblock "js" %}<script src="{% static 'aldryn_bootstrap3/js/dropzone.min.js' %}"></script>{% endaddtoblock %}
+    {% addtoblock "js" %}<script src="{% static 'aldryn_bootstrap3/js/dropzone.init.js' %}"></script>{% endaddtoblock %}
 {% endif %}
-    <div class="js-original-image">
-        <img
-            {% if instance.use_original_image %}
-                src="{{ instance.file.url }}"
-            {% else %}
-                {% with main_src=instance.srcset.lg %}
-                    {% thumbnail instance.file main_src.size crop=main_src.crop upscale=main_src.upscale subject_location=main_src.subject_location as main_thumb %}
-                    src="{{ main_thumb.url }}"
-                {% endwith %}
-            {% endif %}
-            alt="{{ instance.alt }}"
-            {% if instance.title %}title="{{ instance.title }}"{% endif %}
-            {% if instance.img_responsive or instance.shape or instance.thumbnail or instance.classes %}
-                class="{% if instance.img_responsive %}img-responsive{% endif %}{% if instance.shape %} img-{{ instance.shape }}{% endif %}{% if instance.thumbnail %} img-thumbnail{% endif %}{% if instance.classes %} {{ instance.classes }}{% endif %}"
-            {% endif %}
-            {% comment %}
-            {# INFO: needs proper attributes for validation #}
-            srcset="{% for device, src in instance.srcset.items %}
-                {% if not forloop.first %}
-                    {% thumbnail instance.file src.size crop=src.crop upscale=src.upscale subject_location=src.subject_location as thumb %}{{ thumb.url }} {{ src.width_str }}{% if not forloop.last %},{% endif %}
-                {% endif %}
-            {% endfor %}"
-            {% endcomment %}
-        >
-    </div>
-{% if has_dnd_support %}
-        <div class="filer-dropzone-info-message js-filer-dropzone-info-message hidden">
-            <div class="icon"><span class="fa fa-cloud-upload"></span></div>
 
-            <div class="filer-dropzone-upload-welcome js-filer-dropzone-upload-welcome">
-                <div class="text">{% trans 'Drop your file to change image:' %}</div>
-            </div>
+{% spaceless %}
+    {% if request.toolbar and request.toolbar.show_toolbar and request.toolbar.edit_mode %}
+        {% if has_dnd_support %}
+            <div class="js-filer-dropzone filer-dropzone" data-filer-url="{% url 'admin:bootstrap3_image_ajax_upload' pk=instance.pk %}">
+        {% endif %}
+    {% endif %}
+                <img
+                    {% if instance.use_original_image %}
+                        src="{{ instance.file.url }}"
+                    {% else %}
+                        {% with main_src=instance.srcset.lg %}
+                            {% thumbnail instance.file main_src.size crop=main_src.crop upscale=main_src.upscale subject_location=main_src.subject_location as main_thumb %}
+                            src="{{ main_thumb.url }}"
+                        {% endwith %}
+                    {% endif %}
+                    alt="{{ instance.alt }}"
+                    {% if instance.title %}title="{{ instance.title }}"{% endif %}
+                    {% if instance.img_responsive or instance.shape or instance.thumbnail or instance.classes or request.toolbar %}
+                        class="{% if request.toolbar and request.toolbar.show_toolbar and request.toolbar.edit_mode %}js-original-image {% endif %}{% if instance.img_responsive %}img-responsive{% endif %}{% if instance.shape %} img-{{ instance.shape }}{% endif %}{% if instance.thumbnail %} img-thumbnail{% endif %}{% if instance.classes %} {{ instance.classes }}{% endif %}"
+                    {% endif %}
+                    {% comment %}
+                    {# INFO: needs proper attributes for validation #}
+                    srcset="{% for device, src in instance.srcset.items %}
+                        {% if not forloop.first %}
+                            {% thumbnail instance.file src.size crop=src.crop upscale=src.upscale subject_location=src.subject_location as thumb %}{{ thumb.url }} {{ src.width_str }}{% if not forloop.last %},{% endif %}
+                        {% endif %}
+                    {% endfor %}"
+                    {% endcomment %}
+                >
+    {% if request.toolbar and request.toolbar.show_toolbar and request.toolbar.edit_mode %}
+        {% if has_dnd_support %}
+                <div class="filer-dropzone-info-message js-filer-dropzone-info-message hidden">
+                    <div class="icon"><span class="fa fa-cloud-upload"></span></div>
 
-            <div class="filer-dropzone-upload-info js-filer-dropzone-upload-info hidden">
-                <div class="js-filer-dropzone-file-name filer-dropzone-file-name"></div>
-                <div class="filer-dropzone-progress js-filer-dropzone-progress"></div>
-            </div>
+                    <div class="filer-dropzone-upload-welcome js-filer-dropzone-upload-welcome">
+                        <div class="text">{% trans 'Drop your file to change image:' %}</div>
+                    </div>
 
-            <div class="js-filer-dropzone-upload-success hidden">
-                {% trans 'Upload success!' %}
+                    <div class="filer-dropzone-upload-info js-filer-dropzone-upload-info hidden">
+                        <div class="js-filer-dropzone-file-name filer-dropzone-file-name"></div>
+                        <div class="filer-dropzone-progress js-filer-dropzone-progress"></div>
+                    </div>
+
+                    <div class="js-filer-dropzone-upload-success hidden">
+                        {% trans 'Upload success!' %}
+                    </div>
+                </div>
+                <div class="filer-dropzone-error-message js-filer-dropzone-error-message hidden">
+                    <div class="icon"><span class="fa fa-cloud-upload"></span></div>
+                    <div class="js-filer-dropzone-upload-accept">
+                        {% trans 'Error! Files of this type are not accepted.' %}
+                    </div>
+                </div>
             </div>
-        </div>
-        <div class="filer-dropzone-error-message js-filer-dropzone-error-message hidden">
-            <div class="icon"><span class="fa fa-cloud-upload"></span></div>
-            <div class="js-filer-dropzone-upload-accept">
-                {% trans 'Error! Files of this type are not accepted.' %}
-            </div>
-        </div>
-    </div>
-{% endif %}
+        {% endif %}{# has_dnd_support #}
+    {% endif %}{# toolbar #}
+{% endspaceless %}
 {% if 0 %}
     <pre>
         {% with main_src=instance.srcset.lg %}


### PR DESCRIPTION
1. No longer loads css and js when we're not logged into cms and not in "Edit" mode (meaning cannot uplaod image unless "editing" a page)
2. Different upload placeholder
3. Different positioning of the message window
4. Updates the publish button and revert to live buttons
5. removed extra div

reasoning for fixed position - if the image is small - info window overlaps it and blinks infinitely

Before:
![screen shot 2016-01-26 at 13 41 03 3](https://cloud.githubusercontent.com/assets/366813/12580761/783f21a8-c432-11e5-92a5-48d607b242ad.png)

After:
![screen shot 2016-01-26 at 13 40 02 3](https://cloud.githubusercontent.com/assets/366813/12580763/7dc51a88-c432-11e5-8354-0d356dccffea.png)
