### PR TITLE
removes spaces before and after link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,11 +1,15 @@
 CHANGELOG
 =========
 
+1.1.0 (2016-xx-xx)
+------------------
+
+* Removes spaces before and after link
+
 1.0.9 (2016-03-16)
 ------------------
 
 * Removes unnecessary `cache = False` from plugins
-
 
 1.0.8 (2016-02-22)
 ------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-1.1.0 (2016-xx-xx)
+1.0.10 (2016-xx-xx)
 ------------------
 
 * Removes spaces before and after link

--- a/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/button.html
+++ b/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/button.html
@@ -1,6 +1,4 @@
-{% load cms_tags %}
-
-<a href="{{ instance.get_link_url }}"
+{% load cms_tags %}<a href="{{ instance.get_link_url }}"
    {% if instance.type == 'btn' or instance.txt_context or instance.classes %}
    class="
         {% if instance.type == 'btn' %}


### PR DESCRIPTION
**This pull request fixes the following issues**:

|BEFORE|AFTER|
|---|---|
|![screen shot 2016-04-06 at 09 36 29](https://cloud.githubusercontent.com/assets/2270884/14309530/5bd89e6c-fbdd-11e5-835a-b3cfebd784bc.png)|![screen shot 2016-04-06 at 09 51 06](https://cloud.githubusercontent.com/assets/2270884/14309534/61ac49ce-fbdd-11e5-95be-51d47a8b3aa9.png)|

