### PR TITLE
Fixed styling issues with attributes field

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,9 @@ CHANGELOG
 ------------------
 
 * Let attributes field be optional
+* Fixed styling issues with attributes field
+* Changed the "label" plugin template to include no whitespace inside or
+  outside the span
 
 
 1.1.1 (2016-07-05)

--- a/aldryn_bootstrap3/forms.py
+++ b/aldryn_bootstrap3/forms.py
@@ -130,7 +130,7 @@ class LinkForm(django.forms.models.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(LinkForm, self).__init__(*args, **kwargs)
-        self.fields['link_attributes'].widget = AttributesWidget(val_attrs={'style': 'width:500px!important'})
+        self.fields['link_attributes'].widget = AttributesWidget()
 
     def _get_media(self):
         """
@@ -205,5 +205,5 @@ class CarouselSlidePluginForm(django.forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CarouselSlidePluginForm, self).__init__(*args, **kwargs)
-        self.fields['link_attributes'].widget = AttributesWidget(val_attrs={'style': 'width:500px!important'})
+        self.fields['link_attributes'].widget = AttributesWidget()
 

--- a/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/label.html
+++ b/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/label.html
@@ -1,12 +1,3 @@
-{% load cms_tags %}
-
-<span class="label
+{% load cms_tags %}<span class="label
     {% if instance.context %} label-{{ instance.context }}{% endif %}
-    {% if instance.classes %} {{ instance.classes }}{% endif %}">
-
-    {{ instance.label }}
-
-    {% for plugin in instance.child_plugin_instances %}
-        {% render_plugin plugin %}
-    {% endfor %}
-</span>
+    {% if instance.classes %} {{ instance.classes }}{% endif %}">{{ instance.label }}{% for plugin in instance.child_plugin_instances %} {% render_plugin plugin %} {% endfor %}</span>


### PR DESCRIPTION
Since divio/djangocms-attributes-field#14
it is no longer required to pass custom width for the input since
it is going to be handled correctly by the field itself.

Also changed the "label" plugin template to include no whitespace inside or outside the span.

So on the markup like this `text<plugin>text`
before:
![screen shot 2016-07-08 at 18 04 54](https://cloud.githubusercontent.com/assets/366813/16693680/9f4a4c20-4536-11e6-8917-6f3df382dbbb.png)

after:
![screen shot 2016-07-08 at 18 04 42](https://cloud.githubusercontent.com/assets/366813/16693687/a511e3fc-4536-11e6-8711-573db3036cb0.png)

