### PR TITLE
Allowed custom iconsets

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ CHANGELOG
   outside the span
 * Pinned djangocms-attributes-field to v0.1.1+
 * Disabled "text preview" for the Spacer plugin
+* Changed JavaScript to allow custom iconsets
 
 
 1.1.1 (2016-07-05)

--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/js/base.js
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/js/base.js
@@ -84,6 +84,12 @@
                 var initialValue = iconPickerButton.data('icon');
                 var initialIconset = iconSet.find('option[data-prefix=' + data.iconset + ']').attr('value');
 
+                try {
+                    // in case custom iconset is used
+                    initialIconset = JSON.parse(initialIconset);
+                } catch (e) {
+                }
+
                 // initialize bootstrap iconpicker functionality
                 iconPickerButton.iconpicker({
                     arrowClass: 'btn-default',


### PR DESCRIPTION
The library we use for the iconpicker allows for completely custom iconsets when passed js object, but our js that initialized it isn't prepared for this possibility

e.g. if i have
```
ALDRYN_BOOTSTRAP3_ICONSETS = (
    (json.dumps({
        "iconClass": "icon",
        "iconClassFix": "icon-",
        "icons": [
            "custom1",
            "custom2",
        ]
    }), 'custom', 'Custom icons'),
)
```

I can have custom icon set. This PR changes js to allow for that.