### PR TITLE
Improved edit mode preview of image plugin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ CHANGELOG
 * Pinned djangocms-attributes-field to v0.1.1+
 * Disabled "text preview" for the Spacer plugin
 * Changed JavaScript to allow custom iconsets
+* Improved edit mode preview of image plugin
 
 
 1.1.1 (2016-07-05)

--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/css/base.css
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/css/base.css
@@ -174,6 +174,9 @@
 
 /*##############################################################################
 // IMAGE PLUGIN WITH DRAG AND DROP FEATURE */
+.filer-dropzone-image-plugin {
+    display: inline-block;
+}
 .filer-dropzone.dz-drag-hover {
     background: #E5F8FF;
     box-shadow: 0 0 0 2px #00BAFF;
@@ -187,6 +190,7 @@
 .filer-dropzone-info-message,
 .filer-dropzone-error-message {
     position: fixed;
+    display: block;
     left: 50%;
     bottom: 0;
     overflow: hidden;
@@ -205,22 +209,27 @@
 }
 .filer-dropzone-info-message .filer-dropzone-icon,
 .filer-dropzone-error-message .filer-dropzone-icon {
+    display: block;
     font-size: 35px;
     color: #0bf;
 }
 .filer-dropzone-info-message .filer-dropzone-text,
 .filer-dropzone-error-message .filer-dropzone-text {
+    display: block;
     margin: 5px 0 10px 0;
 }
 .filer-dropzone-upload-info {
+    display: block;
     margin-top: 10px;
 }
 .filer-dropzone-upload-info  .filer-dropzone-file-name {
+    display: block;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 .filer-dropzone-progress {
+    display: block;
     height: 5px;
     margin-top: 5px;
     background-color: #0bf;

--- a/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/image.html
+++ b/aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/image.html
@@ -20,7 +20,7 @@ TODO: currently we're always upscaling the image physically.
 {% spaceless %}
     {% if request.toolbar and request.toolbar.show_toolbar and request.toolbar.edit_mode %}
         {% if has_dnd_support %}
-            <div class="js-filer-dropzone filer-dropzone" data-filer-url="{% url 'admin:bootstrap3_image_ajax_upload' pk=instance.pk %}">
+            <span class="js-filer-dropzone filer-dropzone filer-dropzone-image-plugin" data-filer-url="{% url 'admin:bootstrap3_image_ajax_upload' pk=instance.pk %}">
         {% endif %}
     {% endif %}
                 <img
@@ -48,29 +48,29 @@ TODO: currently we're always upscaling the image physically.
                 >
     {% if request.toolbar and request.toolbar.show_toolbar and request.toolbar.edit_mode %}
         {% if has_dnd_support %}
-                <div class="filer-dropzone-info-message js-filer-dropzone-info-message hidden">
-                    <div class="filer-dropzone-icon"><span class="fa fa-cloud-upload"></span></div>
+                <span class="filer-dropzone-info-message js-filer-dropzone-info-message hidden">
+                    <span class="filer-dropzone-icon"><span class="fa fa-cloud-upload"></span></span>
 
-                    <div class="filer-dropzone-upload-welcome js-filer-dropzone-upload-welcome">
-                        <div class="text">{% trans 'Drop your file to change image:' %}</div>
-                    </div>
+                    <span class="filer-dropzone-upload-welcome js-filer-dropzone-upload-welcome">
+                        <span class="text">{% trans 'Drop your file to change image:' %}</span>
+                    </span>
 
-                    <div class="filer-dropzone-upload-info js-filer-dropzone-upload-info hidden">
-                        <div class="js-filer-dropzone-file-name filer-dropzone-file-name"></div>
-                        <div class="filer-dropzone-progress js-filer-dropzone-progress"></div>
-                    </div>
+                    <span class="filer-dropzone-upload-info js-filer-dropzone-upload-info hidden">
+                        <span class="js-filer-dropzone-file-name filer-dropzone-file-name"></span>
+                        <span class="filer-dropzone-progress js-filer-dropzone-progress"></span>
+                    </span>
 
-                    <div class="js-filer-dropzone-upload-success hidden">
+                    <span class="js-filer-dropzone-upload-success hidden">
                         {% trans 'Upload success!' %}
-                    </div>
-                </div>
-                <div class="filer-dropzone-error-message js-filer-dropzone-error-message hidden">
-                    <div class="icon"><span class="fa fa-cloud-upload"></span></div>
-                    <div class="js-filer-dropzone-upload-accept filer-dropzone-text">
+                    </span>
+                </span>
+                <span class="filer-dropzone-error-message js-filer-dropzone-error-message hidden">
+                    <span class="icon"><span class="fa fa-cloud-upload"></span></span>
+                    <span class="js-filer-dropzone-upload-accept filer-dropzone-text">
                         {% trans 'Error! Files of this type are not accepted.' %}
-                    </div>
-                </div>
-            </div>
+                    </span>
+                </span>
+            </span>
         {% endif %}{# has_dnd_support #}
     {% endif %}{# toolbar #}
 {% endspaceless %}


### PR DESCRIPTION
Since in image can be put inside of p tag, plugin representation can never have any divs, that breaks layout. This pull request changes the display properties of the wrapper, so things like centering would work.

Ideally we should remove any extra markup, but have no time for this at the moment.