### PR TITLE
Fixed a bug in Link/Button plugin preview

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ CHANGELOG
 * Disabled "text preview" for the Spacer plugin
 * Changed JavaScript to allow custom iconsets
 * Improved edit mode preview of image plugin
+* Fixed a bug in Link/Button plugin preview not always respecting icon options
 
 
 1.1.1 (2016-07-05)

--- a/aldryn_bootstrap3/static/aldryn_bootstrap3/js/base.js
+++ b/aldryn_bootstrap3/static/aldryn_bootstrap3/js/base.js
@@ -221,14 +221,15 @@
                     } else {
                         previewBtn.find('.pre').hide();
                     }
-                });
+                }).trigger('change');
+
                 $('#id_icon_right').on('change', function () {
                     if ($(this).is(':checked')) {
                         previewBtn.find('.post').show();
                     } else {
                         previewBtn.find('.post').hide();
                     }
-                });
+                }).trigger('change');
 
                 // certain elements can only be loaded after a timeout
                 setTimeout(function () {


### PR DESCRIPTION
In case there is a custom icon set set - it immediately picks first
icon from that list and shows it, because on initial render icon
checkboxes are not respected.