### PR TITLE
Fixed a bug with extra whitespace appearing after label and button plugins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+max_line_length = 120
+quote_type = single
+
+[*.{scss,js,html}]
+max_line_length = 120
+indent_style = space
+quote_type = double
+
+[*.js]
+max_line_length = 120
+quote_type = single
+
+[*.rst]
+max_line_length = 80
+
+[*.yml]
+indent_size = 2
+
+[aldryn_bootstrap3/templates/aldryn_bootstrap3/plugins/{button,label}.html]
+insert_final_newline = false

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,8 @@ CHANGELOG
   styles already on the page
 * Fixed an issue with dropzone strings visible inside djangocms-text-ckeditor
   image preview under certain circumstances
+* Fixed a bug with extra whitespace appearing after label and button plugins
+* Added EditorConfig file to prevent regressions in label and button plugins
 
 1.1.2 (2016-09-05)
 ------------------


### PR DESCRIPTION
Also added `.editorconfig` to prevent this in the future