### PR TITLE
Django 1.11 compatibility addressed

### DIFF
--- a/aldryn_bootstrap3/migrations/0001_initial.py
+++ b/aldryn_bootstrap3/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3AlertPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('context', aldryn_bootstrap3.model_fields.Context(default='default', max_length=255)),
                 ('icon', aldryn_bootstrap3.model_fields.Icon(default='', max_length=255, blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3BlockquotePlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('reverse', models.BooleanField(default=False)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
                 ('link_mailto', models.EmailField(max_length=75, null=True, verbose_name='mailto', blank=True)),
                 ('link_phone', models.CharField(max_length=40, null=True, verbose_name='Phone', blank=True)),
                 ('link_target', models.CharField(blank=True, max_length=100, verbose_name='target', choices=[('', 'same window'), ('_blank', 'new window'), ('_parent', 'parent window'), ('_top', 'topmost frame')])),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('label', models.CharField(default='', max_length=256, verbose_name='label', blank=True)),
                 ('type', aldryn_bootstrap3.model_fields.LinkOrButton(default='lnk', max_length=10)),
                 ('btn_context', aldryn_bootstrap3.model_fields.Context(default='default', max_length=255, verbose_name='context', blank=True, choices=[('default', 'Default'), ('primary', 'Primary'), ('success', 'Success'), ('info', 'Info'), ('warning', 'Warning'), ('danger', 'Danger'), ('link', 'Link Button'), ('', 'Custom')])),
@@ -75,7 +75,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3IconPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('icon', aldryn_bootstrap3.model_fields.Icon(default='', max_length=255, blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -87,7 +87,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3ImagePlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('alt', aldryn_bootstrap3.model_fields.MiniText(default='', verbose_name='alt', blank=True)),
                 ('title', aldryn_bootstrap3.model_fields.MiniText(default='', verbose_name='title', blank=True)),
                 ('aspect_ratio', models.CharField(default='', max_length=10, verbose_name='aspect ratio', blank=True, choices=[('1x1', '1x1'), ('4x3', '4x3'), ('16x9', '16x9'), ('16x10', '16x10'), ('21x9', '21x9'), ('1x1', '1x1'), ('3x4', '3x4'), ('9x16', '9x16'), ('10x16', '10x16'), ('9x21', '9x21')])),
@@ -105,7 +105,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3LabelPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('label', models.CharField(default='', max_length=256, verbose_name='label', blank=True)),
                 ('context', aldryn_bootstrap3.model_fields.Context(default='default', max_length=255, choices=[('default', 'Default'), ('primary', 'Primary'), ('success', 'Success'), ('info', 'Info'), ('warning', 'Warning'), ('danger', 'Danger')])),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
@@ -118,7 +118,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3PanelBodyPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
             options={
@@ -129,7 +129,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3PanelFooterPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
             options={
@@ -140,7 +140,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3PanelHeadingPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('title', aldryn_bootstrap3.model_fields.MiniText(default='', help_text='Alternatively you can add plugins', verbose_name='title', blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -152,7 +152,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3PanelPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('context', aldryn_bootstrap3.model_fields.Context(default='default', max_length=255, choices=[('default', 'Default'), ('primary', 'Primary'), ('success', 'Success'), ('info', 'Info'), ('warning', 'Warning'), ('danger', 'Danger')])),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -164,7 +164,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3SpacerPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('size', aldryn_bootstrap3.model_fields.Size(default='md', max_length=255, blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -176,7 +176,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Boostrap3WellPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('size', aldryn_bootstrap3.model_fields.Size(default='md', max_length=255, blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -188,7 +188,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3AccordionItemPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('title', aldryn_bootstrap3.model_fields.MiniText(default='', verbose_name='title', blank=True)),
                 ('context', aldryn_bootstrap3.model_fields.Context(default='default', max_length=255, choices=[('default', 'Default'), ('primary', 'Primary'), ('success', 'Success'), ('info', 'Info'), ('warning', 'Warning'), ('danger', 'Danger')])),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
@@ -201,7 +201,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3AccordionPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('index', models.PositiveIntegerField(help_text='index of element that should be opened on page load (leave it empty if none of the items should be opened)', null=True, verbose_name='index', blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
@@ -213,7 +213,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3CarouselPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('style', models.CharField(default='standard', max_length=50, verbose_name='Style', choices=[('standard', 'Standard')])),
                 ('aspect_ratio', models.CharField(default='', max_length=10, verbose_name='aspect ratio', blank=True, choices=[('1x1', '1x1'), ('4x3', '4x3'), ('16x9', '16x9'), ('16x10', '16x10'), ('21x9', '21x9'), ('1x1', '1x1'), ('3x4', '3x4'), ('9x16', '9x16'), ('10x16', '10x16'), ('9x21', '9x21')])),
                 ('transition_effect', models.CharField(default='', max_length=50, verbose_name='Transition Effect', blank=True, choices=[('slide', 'Slide')])),
@@ -231,7 +231,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3CarouselSlideFolderPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
                 ('folder', filer.fields.folder.FilerFolderField(verbose_name='folder', to='filer.Folder')),
             ],
@@ -243,7 +243,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3CarouselSlidePlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('link_url', models.URLField(default='', verbose_name='link', blank=True)),
                 ('link_anchor', models.CharField(help_text='Adds this value as an anchor (#my-anchor) to the link.', max_length=128, verbose_name='anchor', blank=True)),
                 ('link_mailto', models.EmailField(max_length=75, null=True, verbose_name='mailto', blank=True)),
@@ -264,7 +264,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3ColumnPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
                 ('tag', models.SlugField(default='div')),
                 ('xs_col', aldryn_bootstrap3.model_fields.IntegerField(default=None, null=True, verbose_name='col-xs-', blank=True)),
@@ -292,7 +292,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3ListGroupItemPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('title', aldryn_bootstrap3.model_fields.MiniText(default='', verbose_name='title', blank=True)),
                 ('context', aldryn_bootstrap3.model_fields.Context(default='', max_length=255, blank=True, choices=[('', 'None'), ('primary', 'Primary'), ('success', 'Success'), ('info', 'Info'), ('warning', 'Warning'), ('danger', 'Danger')])),
                 ('state', models.CharField(blank=True, max_length=255, verbose_name='state', choices=[('active', 'active'), ('disabled', 'disabled')])),
@@ -306,7 +306,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3ListGroupPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
                 ('add_list_group_class', models.BooleanField(default=True, help_text='whether to add the list-group and list-group-item classes', verbose_name='class: list-group')),
             ],
@@ -318,7 +318,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3RowPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='space separated classes that are added to the class. see <a href="http://getbootstrap.com/css/" target="_blank">bootstrap docs</a>', blank=True)),
             ],
             options={

--- a/aldryn_bootstrap3/migrations/0002_bootstrap3fileplugin.py
+++ b/aldryn_bootstrap3/migrations/0002_bootstrap3fileplugin.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bootstrap3FilePlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('name', aldryn_bootstrap3.model_fields.MiniText(default='', verbose_name='name', blank=True)),
                 ('open_new_window', models.BooleanField(default=False)),
                 ('show_file_size', models.BooleanField(default=False)),

--- a/aldryn_bootstrap3/migrations/0008_auto_20160820_2332.py
+++ b/aldryn_bootstrap3/migrations/0008_auto_20160820_2332.py
@@ -14,46 +14,46 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3accordionitemplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3accordionplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3carouselplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3carouselslidefolderplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3carouselslideplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3columnplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3listgroupitemplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3listgroupplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3rowplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='+', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
     ]

--- a/aldryn_bootstrap3/migrations/0009_auto_20161219_1530.py
+++ b/aldryn_bootstrap3/migrations/0009_auto_20161219_1530.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='Space separated classes that are added to the class. See <a href="http://getbootstrap.com/css/" target="_blank">Bootstrap 3 documentation</a>.', verbose_name='Classes', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3citeplugin', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3citeplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -142,7 +142,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3alertplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3alertplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3alertplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3alertplugin',
@@ -157,7 +157,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3blockquoteplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3blockquoteplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3blockquoteplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3blockquoteplugin',
@@ -187,7 +187,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3buttonplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3buttonplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3buttonplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3buttonplugin',
@@ -257,7 +257,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3iconplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3iconplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3iconplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3imageplugin',
@@ -277,7 +277,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3imageplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3imageplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3imageplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3imageplugin',
@@ -327,7 +327,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3labelplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3labelplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3labelplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3labelplugin',
@@ -342,7 +342,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3panelbodyplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelbodyplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelbodyplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3panelfooterplugin',
@@ -352,7 +352,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3panelfooterplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelfooterplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelfooterplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3panelheadingplugin',
@@ -362,7 +362,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3panelheadingplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelheadingplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelheadingplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3panelheadingplugin',
@@ -377,7 +377,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3panelplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3panelplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3spacerplugin',
@@ -387,7 +387,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3spacerplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3spacerplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3spacerplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3spacerplugin',
@@ -402,7 +402,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='boostrap3wellplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3wellplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3wellplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='boostrap3wellplugin',
@@ -417,7 +417,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3accordionitemplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3accordionitemplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3accordionitemplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3accordionitemplugin',
@@ -432,7 +432,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3accordionplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3accordionplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3accordionplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3accordionplugin',
@@ -452,7 +452,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3carouselplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3carouselplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3carouselplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3carouselplugin',
@@ -482,7 +482,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3carouselslidefolderplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3carouselslidefolderplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3carouselslidefolderplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3carouselslidefolderplugin',
@@ -497,7 +497,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3carouselslideplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3carouselslideplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3carouselslideplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3carouselslideplugin',
@@ -552,7 +552,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3columnplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3columnplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3columnplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3columnplugin',
@@ -567,7 +567,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3fileplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3fileplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3fileplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3fileplugin',
@@ -597,7 +597,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3listgroupitemplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3listgroupitemplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3listgroupitemplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3listgroupitemplugin',
@@ -627,7 +627,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3listgroupplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3listgroupplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3listgroupplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='bootstrap3rowplugin',
@@ -637,6 +637,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bootstrap3rowplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3rowplugin', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3rowplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
     ]

--- a/aldryn_bootstrap3/migrations/0010_bootstrap3codeplugin.py
+++ b/aldryn_bootstrap3/migrations/0010_bootstrap3codeplugin.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('code', models.TextField(verbose_name='Code', blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='Space separated classes that are added to the class. See <a href="http://getbootstrap.com/css/" target="_blank">Bootstrap 3 documentation</a>.', verbose_name='Classes', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3codeplugin', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3codeplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/aldryn_bootstrap3/migrations/0011_bootstrap3responsiveplugin.py
+++ b/aldryn_bootstrap3/migrations/0011_bootstrap3responsiveplugin.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('print_breakpoints', aldryn_bootstrap3.model_fields.ResponsivePrint(default='visible-print', verbose_name='Print', blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='Space separated classes that are added to the class. See <a href="http://getbootstrap.com/css/" target="_blank">Bootstrap 3 documentation</a>.', verbose_name='Classes', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3responsiveplugin', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3responsiveplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/aldryn_bootstrap3/migrations/0012_bootstrap3tabplugin.py
+++ b/aldryn_bootstrap3/migrations/0012_bootstrap3tabplugin.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('icon', aldryn_bootstrap3.model_fields.Icon(default='', max_length=255, verbose_name='Title icon', blank=True)),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='Space separated classes that are added to the class. See <a href="http://getbootstrap.com/css/" target="_blank">Bootstrap 3 documentation</a>.', verbose_name='Classes', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3tabitemplugin', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3tabitemplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                 ('effect', models.CharField(blank=True, max_length=255, verbose_name='Animation effect', choices=[('fade', 'Fade')])),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='Space separated classes that are added to the class. See <a href="http://getbootstrap.com/css/" target="_blank">Bootstrap 3 documentation</a>.', verbose_name='Classes', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3tabplugin', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_bootstrap3tabplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/aldryn_bootstrap3/migrations/0013_boostrap3jumbotronplugin.py
+++ b/aldryn_bootstrap3/migrations/0013_boostrap3jumbotronplugin.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('grid', models.BooleanField(default=False, help_text='Adds a "container" element inside of the "Jumbotron"for use outside of a grid.', verbose_name='Add container')),
                 ('classes', aldryn_bootstrap3.model_fields.Classes(default='', help_text='Space separated classes that are added to the class. See <a href="http://getbootstrap.com/css/" target="_blank">Bootstrap 3 documentation</a>.', verbose_name='Classes', blank=True)),
                 ('attributes', djangocms_attributes_field.fields.AttributesField(default=dict, verbose_name='Attributes', blank=True)),
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3jumbotronplugin', primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='aldryn_bootstrap3_boostrap3jumbotronplugin', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/aldryn_bootstrap3/model_fields.py
+++ b/aldryn_bootstrap3/model_fields.py
@@ -57,6 +57,7 @@ CMSPluginField = partial(
     to=CMSPlugin,
     related_name='%(app_label)s_%(class)s',
     parent_link=True,
+    on_delete=models.CASCADE,
 )
 
 

--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -55,7 +55,7 @@ class Bootstrap3RowPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return str(self.pk)
@@ -98,7 +98,7 @@ class Bootstrap3ColumnPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         txt = ' '.join([self.get_column_classes(), self.classes])
@@ -198,7 +198,7 @@ class Boostrap3BlockquotePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         if self.reverse:
@@ -219,7 +219,7 @@ class Boostrap3CitePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return ''
@@ -256,7 +256,7 @@ class Bootstrap3CodePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return '<{}>'.format(self.code_type)
@@ -306,7 +306,7 @@ class Boostrap3ButtonPlugin(CMSPlugin, model_fields.LinkMixin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.label
@@ -393,7 +393,7 @@ class Boostrap3ImagePlugin(CMSPlugin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         txt = ''
@@ -460,7 +460,7 @@ class Bootstrap3ResponsivePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         text = self.device_breakpoints
@@ -517,7 +517,7 @@ class Boostrap3IconPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.icon
@@ -550,7 +550,7 @@ class Boostrap3LabelPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.label
@@ -581,7 +581,7 @@ class Boostrap3JumbotronPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.label or str(self.pk)
@@ -606,7 +606,7 @@ class Boostrap3AlertPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.classes
@@ -630,7 +630,7 @@ class Bootstrap3ListGroupPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def get_short_description(self):
         instance = self.get_plugin_instance()[0]
@@ -682,7 +682,7 @@ class Bootstrap3ListGroupItemPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.title
@@ -709,7 +709,7 @@ class Boostrap3PanelPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.context
@@ -734,7 +734,7 @@ class Boostrap3PanelHeadingPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.title
@@ -753,7 +753,7 @@ class Boostrap3PanelBodyPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.classes
@@ -772,7 +772,7 @@ class Boostrap3PanelFooterPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.classes
@@ -794,7 +794,7 @@ class Boostrap3WellPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.classes
@@ -861,7 +861,7 @@ class Bootstrap3TabPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return '{} {}'.format(self.style, self.effect)
@@ -887,7 +887,7 @@ class Bootstrap3TabItemPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.title
@@ -912,7 +912,7 @@ class Bootstrap3AccordionPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def get_short_description(self):
         instance = self.get_plugin_instance()[0]
@@ -958,7 +958,7 @@ class Bootstrap3AccordionItemPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return self.title
@@ -1033,7 +1033,7 @@ class Bootstrap3CarouselPlugin(CMSPlugin):
         ],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         data = django.forms.models.model_to_dict(self)
@@ -1117,7 +1117,7 @@ class Bootstrap3CarouselSlidePlugin(CMSPlugin, model_fields.LinkMixin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         image_text = content_text = ''
@@ -1154,7 +1154,7 @@ class Bootstrap3CarouselSlideFolderPlugin(CMSPlugin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         if self.folder_id:
@@ -1184,7 +1184,7 @@ class Boostrap3SpacerPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         return 'size-' + self.size + ' ' + self.classes
@@ -1226,7 +1226,7 @@ class Bootstrap3FilePlugin(CMSPlugin):
         excluded_keys=['class', 'target'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
+    cmsplugin_ptr = model_fields.CMSPluginField()
 
     def __str__(self):
         label = self.name

--- a/aldryn_bootstrap3/models.py
+++ b/aldryn_bootstrap3/models.py
@@ -55,7 +55,7 @@ class Bootstrap3RowPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return str(self.pk)
@@ -98,7 +98,7 @@ class Bootstrap3ColumnPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         txt = ' '.join([self.get_column_classes(), self.classes])
@@ -198,7 +198,7 @@ class Boostrap3BlockquotePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         if self.reverse:
@@ -219,7 +219,7 @@ class Boostrap3CitePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return ''
@@ -256,7 +256,7 @@ class Bootstrap3CodePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return '<{}>'.format(self.code_type)
@@ -306,7 +306,7 @@ class Boostrap3ButtonPlugin(CMSPlugin, model_fields.LinkMixin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.label
@@ -393,7 +393,7 @@ class Boostrap3ImagePlugin(CMSPlugin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         txt = ''
@@ -460,7 +460,7 @@ class Bootstrap3ResponsivePlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         text = self.device_breakpoints
@@ -517,7 +517,7 @@ class Boostrap3IconPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.icon
@@ -550,7 +550,7 @@ class Boostrap3LabelPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.label
@@ -581,7 +581,7 @@ class Boostrap3JumbotronPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.label or str(self.pk)
@@ -606,7 +606,7 @@ class Boostrap3AlertPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.classes
@@ -630,7 +630,7 @@ class Bootstrap3ListGroupPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def get_short_description(self):
         instance = self.get_plugin_instance()[0]
@@ -682,7 +682,7 @@ class Bootstrap3ListGroupItemPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.title
@@ -709,7 +709,7 @@ class Boostrap3PanelPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.context
@@ -734,7 +734,7 @@ class Boostrap3PanelHeadingPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.title
@@ -753,7 +753,7 @@ class Boostrap3PanelBodyPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.classes
@@ -772,7 +772,7 @@ class Boostrap3PanelFooterPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.classes
@@ -794,7 +794,7 @@ class Boostrap3WellPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.classes
@@ -861,7 +861,7 @@ class Bootstrap3TabPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return '{} {}'.format(self.style, self.effect)
@@ -887,7 +887,7 @@ class Bootstrap3TabItemPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.title
@@ -912,7 +912,7 @@ class Bootstrap3AccordionPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def get_short_description(self):
         instance = self.get_plugin_instance()[0]
@@ -958,7 +958,7 @@ class Bootstrap3AccordionItemPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return self.title
@@ -1033,7 +1033,7 @@ class Bootstrap3CarouselPlugin(CMSPlugin):
         ],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         data = django.forms.models.model_to_dict(self)
@@ -1117,7 +1117,7 @@ class Bootstrap3CarouselSlidePlugin(CMSPlugin, model_fields.LinkMixin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         image_text = content_text = ''
@@ -1154,7 +1154,7 @@ class Bootstrap3CarouselSlideFolderPlugin(CMSPlugin):
     )
     classes = model_fields.Classes()
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         if self.folder_id:
@@ -1184,7 +1184,7 @@ class Boostrap3SpacerPlugin(CMSPlugin):
         excluded_keys=['class'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         return 'size-' + self.size + ' ' + self.classes
@@ -1226,7 +1226,7 @@ class Bootstrap3FilePlugin(CMSPlugin):
         excluded_keys=['class', 'target'],
     )
 
-    cmsplugin_ptr = model_fields.CMSPluginField()
+    cmsplugin_ptr = model_fields.CMSPluginField(on_delete=models.CASCADE)
 
     def __str__(self):
         label = self.name

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/context.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/context.html
@@ -2,9 +2,17 @@
 
 <div class="aldryn-bootstrap3 aldryn-bootstrap3-context" data-context="{{ selects.name }}">
     <div class="btn-group js-btn-group-context-{{ selects.name }}" data-toggle="buttons">
-        {% for group, options, index in widget.optgroups %}
-          {% for option in options %}
-            {% include option.template_name with widget=option %}{% endfor %}
-        {% endfor %}
+        {% if widget %}
+            {# Django 1.11+ #}
+            {% for group, options, index in widget.optgroups %}
+              {% for option in options %}
+                {% include option.template_name with widget=option %}{% endfor %}
+            {% endfor %}
+        {% elif selects %}
+            {# Django < 1.11 #}
+            {% for item in selects %}
+                {{ item }}
+            {% endfor %}
+        {% endif %}
     </div>
 </div>

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/context.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/context.html
@@ -2,12 +2,9 @@
 
 <div class="aldryn-bootstrap3 aldryn-bootstrap3-context" data-context="{{ selects.name }}">
     <div class="btn-group js-btn-group-context-{{ selects.name }}" data-toggle="buttons">
-        {% for item in selects %}
-            {{ item }}
+        {% for group, options, index in widget.optgroups %}
+          {% for option in options %}
+            {% include option.template_name with widget=option %}{% endfor %}
         {% endfor %}
     </div>
 </div>
-
-{# Available Variables #}
-{# {{ item.choice_value }}: {{ item.choice_label }} #}
-{# selected: {{ selects.value }}  #}

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/link_or_button.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/link_or_button.html
@@ -1,3 +1,4 @@
-{% for item in selects %}
-    {{ item }}
+{% for group, options, index in widget.optgroups %}
+  {% for option in options %}
+    {% include option.template_name with widget=option %}{% endfor %}
 {% endfor %}

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/link_or_button.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/link_or_button.html
@@ -1,4 +1,12 @@
-{% for group, options, index in widget.optgroups %}
-  {% for option in options %}
-    {% include option.template_name with widget=option %}{% endfor %}
-{% endfor %}
+{% if widget %}
+    {# Django 1.11+ #}
+    {% for group, options, index in widget.optgroups %}
+      {% for option in options %}
+        {% include option.template_name with widget=option %}{% endfor %}
+    {% endfor %}
+{% elif selects %}
+    {# Django < 1.11 #}
+    {% for item in selects %}
+        {{ item }}
+    {% endfor %}
+{% endif %}

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/size.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/size.html
@@ -1,7 +1,7 @@
 <div class="btn-group btn-group-sizes js-btn-group-sizes" data-toggle="buttons">
-    {% for item in selects %}
-        {{ item }}
+    {% for group, options, index in widget.optgroups %}
+      {% for option in options %}
+        {% include option.template_name with widget=option %}{% endfor %}
     {% endfor %}
 </div>
 
-{# selected: {{ selects.value }} #}

--- a/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/size.html
+++ b/aldryn_bootstrap3/templates/admin/aldryn_bootstrap3/widgets/size.html
@@ -1,7 +1,14 @@
 <div class="btn-group btn-group-sizes js-btn-group-sizes" data-toggle="buttons">
-    {% for group, options, index in widget.optgroups %}
-      {% for option in options %}
-        {% include option.template_name with widget=option %}{% endfor %}
-    {% endfor %}
+	{% if widget %}
+	    {# Django 1.11+ #}
+	    {% for group, options, index in widget.optgroups %}
+	      {% for option in options %}
+	        {% include option.template_name with widget=option %}{% endfor %}
+	    {% endfor %}
+	{% elif selects %}
+	    {# Django < 1.11 #}
+	    {% for item in selects %}
+	        {{ item }}
+	    {% endfor %}
+	{% endif %}
 </div>
-

--- a/aldryn_bootstrap3/widgets.py
+++ b/aldryn_bootstrap3/widgets.py
@@ -6,13 +6,42 @@ from django.template import loader
 
 from . import constants
 from .conf import settings
+import django
 
+
+if django.VERSION < (1,11):
+    # use RadioFieldRenderer
+
+    class TemplateRenderer(django.forms.widgets.RadioFieldRenderer):
+        template_name = None
+
+        def render(self):
+            from django.template.loader import render_to_string
+            return render_to_string(
+                self.template_name,
+                {'selects': self},
+            )
+else:
+    class TemplateRenderer(object):
+        pass
+
+class ContextRenderer(TemplateRenderer):
+    template_name = 'admin/aldryn_bootstrap3/widgets/context.html'
+
+class SizeRenderer(TemplateRenderer):
+    template_name = 'admin/aldryn_bootstrap3/widgets/size.html'
+
+class LinkOrButtonRenderer(TemplateRenderer):
+    template_name = 'admin/aldryn_bootstrap3/widgets/link_or_button.html'
+    
     
 class Context(django.forms.widgets.RadioSelect):
+    renderer = ContextRenderer
     template_name = 'admin/aldryn_bootstrap3/widgets/context.html'
 
 
 class Size(django.forms.widgets.RadioSelect):
+    renderer = SizeRenderer
     template_name = 'admin/aldryn_bootstrap3/widgets/size.html'
 
 
@@ -52,6 +81,7 @@ class MiniTextarea(django.forms.widgets.Textarea):
 
 
 class LinkOrButton(django.forms.widgets.RadioSelect):
+    renderer = LinkOrButtonRenderer
     template_name = 'admin/aldryn_bootstrap3/widgets/link_or_button.html'
 
 

--- a/aldryn_bootstrap3/widgets.py
+++ b/aldryn_bootstrap3/widgets.py
@@ -2,37 +2,18 @@
 from __future__ import unicode_literals, absolute_import
 
 import django.forms.widgets
+from django.template import loader
 
 from . import constants
 from .conf import settings
 
-
-class ContextRenderer(django.forms.widgets.RadioFieldRenderer):
-    def render(self):
-        from django.template.loader import render_to_string
-        rendered = render_to_string(
-            'admin/aldryn_bootstrap3/widgets/context.html',
-            {'selects': self},
-        )
-        return rendered
-
-
+    
 class Context(django.forms.widgets.RadioSelect):
-    renderer = ContextRenderer
-
-
-class SizeRenderer(django.forms.widgets.RadioFieldRenderer):
-    def render(self):
-        from django.template.loader import render_to_string
-        rendered = render_to_string(
-            'admin/aldryn_bootstrap3/widgets/size.html',
-            {'selects': self},
-        )
-        return rendered
+    template_name = 'admin/aldryn_bootstrap3/widgets/context.html'
 
 
 class Size(django.forms.widgets.RadioSelect):
-    renderer = SizeRenderer
+    template_name = 'admin/aldryn_bootstrap3/widgets/size.html'
 
 
 class Icon(django.forms.widgets.TextInput):
@@ -70,18 +51,8 @@ class MiniTextarea(django.forms.widgets.Textarea):
         super(MiniTextarea, self).__init__(attrs)
 
 
-class LinkOrButtonRenderer(django.forms.widgets.RadioFieldRenderer):
-    def render(self):
-        from django.template.loader import render_to_string
-        rendered = render_to_string(
-            'admin/aldryn_bootstrap3/widgets/link_or_button.html',
-            {'selects': self},
-        )
-        return rendered
-
-
 class LinkOrButton(django.forms.widgets.RadioSelect):
-    renderer = LinkOrButtonRenderer
+    template_name = 'admin/aldryn_bootstrap3/widgets/link_or_button.html'
 
 
 class Responsive(django.forms.widgets.Textarea):


### PR DESCRIPTION
Addressing #157 and #160. This time there is a workaround for backwards compatibility with Django <1.11.  RadioFieldRenderers are loaded up with a template if Django < 1.11.  If Django >= 1.11, then template based rendering is used.  Django 1.11 reworked the whole widget rendering codebase in favor or templates.